### PR TITLE
Bug fix to recursively create source directory

### DIFF
--- a/Hillup/data/SRTM1.py
+++ b/Hillup/data/SRTM1.py
@@ -2,7 +2,7 @@
 """
 from sys import stderr
 from math import floor, log
-from os import unlink, close, write, mkdir, chmod
+from os import unlink, close, write, mkdir, chmod, makedirs
 from os.path import basename, exists, isdir, join
 from httplib import HTTPConnection
 from urlparse import urlparse
@@ -104,7 +104,7 @@ def datasource(lat, lon, source_dir):
         return None
 
     if not exists(dem_dir):
-        mkdir(dem_dir)
+        makedirs(dem_dir)
         chmod(dem_dir, 0777)
 
     assert isdir(dem_dir)

--- a/Hillup/data/SRTM1.py
+++ b/Hillup/data/SRTM1.py
@@ -23,31 +23,31 @@ sref.ImportFromProj4('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
 
 def region(lat, lon):
     """ Return the SRTM1 region number of a given lat, lon.
-    
+
         Map of regions:
         http://dds.cr.usgs.gov/srtm/version2_1/SRTM1/Region_definition.jpg
     """
     if 38 <= lat and lat < 50 and -125 <= lon and lon < -111:
         return 1
-    
+
     if 38 <= lat and lat < 50 and -111 <= lon and lon < -97:
         return 2
-    
+
     if 38 <= lat and lat < 50 and -97 <= lon and lon < -83:
         return 3
-    
+
     if 28 <= lat and lat < 38 and -123 <= lon and lon < -100:
         return 4
-    
+
     if 25 <= lat and lat < 38 and -100 <= lon and lon < -83:
         return 5
-    
+
     if 17 <= lat and lat < 48 and -83 <= lon and lon < -64:
         return 6
-    
+
     if -15 <= lat and lat < 60 and ((172 <= lon and lon < 180) or (-180 <= lon and lon < -129)):
         return 7
-    
+
     raise ValueError('Unknown location: %s, %s' % (lat, lon))
 
 def quads(minlon, minlat, maxlon, maxlat):
@@ -55,19 +55,19 @@ def quads(minlon, minlat, maxlon, maxlat):
     """
     lon = floor(minlon)
     while lon <= maxlon:
-    
+
         lat = floor(minlat)
         while lat <= maxlat:
-        
+
             yield lon, lat
-        
+
             lat += 1
-    
+
         lon += 1
 
 def datasource(lat, lon, source_dir):
     """ Return a gdal datasource for an SRTM1 lat, lon corner.
-    
+
         If it doesn't already exist locally in source_dir, grab a new one.
     """
     #
@@ -82,18 +82,18 @@ def datasource(lat, lon, source_dir):
     # FIXME for western / southern hemispheres
     fmt = 'http://dds.cr.usgs.gov/srtm/version2_1/SRTM1/Region_%02d/N%02dW%03d.hgt.zip'
     url = fmt % (reg, abs(lat), abs(lon))
-    
+
     #
     # Create a local filepath
     #
     s, host, path, p, q, f = urlparse(url)
-    
+
     dem_dir = md5(url).hexdigest()[:3]
     dem_dir = join(source_dir, dem_dir)
-    
+
     dem_path = join(dem_dir, basename(path)[:-4])
     dem_none = dem_path[:-4]+'.404'
-    
+
     #
     # Check if the file exists locally
     #
@@ -106,25 +106,25 @@ def datasource(lat, lon, source_dir):
     if not exists(dem_dir):
         mkdir(dem_dir)
         chmod(dem_dir, 0777)
-    
+
     assert isdir(dem_dir)
-    
+
     #
     # Grab a fresh remote copy
     #
     print >> stderr, 'Retrieving', url, 'in DEM.SRTM1.datasource().'
-    
+
     conn = HTTPConnection(host, 80)
     conn.request('GET', path)
     resp = conn.getresponse()
-    
+
     if resp.status == 404:
         # we're probably outside the coverage area
         print >> open(dem_none, 'w'), url
         return None
-    
+
     assert resp.status == 200, (resp.status, resp.read())
-    
+
     try:
         #
         # Get the DEM out of the zip file
@@ -132,18 +132,18 @@ def datasource(lat, lon, source_dir):
         handle, zip_path = mkstemp(prefix='srtm1-', suffix='.zip')
         write(handle, resp.read())
         close(handle)
-        
+
         zipfile = ZipFile(zip_path, 'r')
-        
+
         #
         # Write the actual DEM
         #
         dem_file = open(dem_path, 'w')
         dem_file.write(zipfile.read(zipfile.namelist()[0]))
         dem_file.close()
-        
+
         chmod(dem_path, 0666)
-    
+
     finally:
         unlink(zip_path)
 

--- a/Hillup/data/SRTM3.py
+++ b/Hillup/data/SRTM3.py
@@ -2,7 +2,7 @@
 """
 from sys import stderr
 from math import floor, log
-from os import unlink, close, write, mkdir, chmod
+from os import unlink, close, write, mkdir, chmod, makedirs
 from os.path import basename, exists, isdir, join
 from httplib import HTTPConnection
 from urlparse import urlparse
@@ -85,7 +85,7 @@ def datasource(lat, lon, source_dir):
         return None
 
     if not exists(dem_dir):
-        mkdir(dem_dir)
+        makedirs(dem_dir)
         chmod(dem_dir, 0777)
 
     assert isdir(dem_dir)


### PR DESCRIPTION
Calling mkdir('source/104') will fail if 'source' doesn't exist.

makedirs() will recursively create the folder.  Alternatively, could manually check/create the base 'source' dir first.

NOTE: I've setup my editor to cleanup whitespace - you can cherry-pick out just the one commit if you'd like.  I've never issued a pull request before... hoping you can git cherry-pick the revisions you want!
