### PR TITLE
Fix: close geotiff files before returning their contents

### DIFF
--- a/Hillup/__init__.py
+++ b/Hillup/__init__.py
@@ -50,6 +50,7 @@ def save_slope_aspect(slope, aspect, wkt, xform, fp, tmpdir):
         band_aspect.WriteRaster(0, 0, w, h, aspect2bytes(aspect).tostring())
         
         ds_both.FlushCache()
+	ds_both = None
         fp.write(open(filename, 'r').read())
     
     finally:


### PR DESCRIPTION
I was having a terrible time with Hillup creating corrupt tiff files -- turns out, at least on RHEL 6, save_slope_aspect was returning bad data. You'd think ds_both.FlushCache would do it, but I confirmed that the on-disk file is corrupt at that point, but correct once the ds_both object is destroyed (thereby calling GDALClose). 
