### PR TITLE
enable hillup-seed to make non-256px tiles

### DIFF
--- a/Hillup/data/__init__.py
+++ b/Hillup/data/__init__.py
@@ -39,12 +39,12 @@ class SeedingLayer (Layer):
     
         Intended for use in hillup-seed.py script for preparing a tile directory.
     """
-    def __init__(self, demdir, tiledir, tmpdir, source):
+    def __init__(self, demdir, tiledir, tmpdir, source, size):
         """
         """
         cache = Disk(tiledir, dirs='safe')
         config = Configuration(cache, '.')
-        Layer.__init__(self, config, SphericalMercator(), Metatile())
+        Layer.__init__(self, config, SphericalMercator(), Metatile(), tile_height=size)
         
         self.provider = Provider(self, demdir, tmpdir, source)
 

--- a/hillup-seed.py
+++ b/hillup-seed.py
@@ -20,7 +20,7 @@ Bounding box is given as a pair of lat/lon coordinates, e.g. "37.788 -122.349
 
 See `%prog --help` for info.""")
 
-defaults = dict(demdir='source', tiledir='out', tmpdir=None, source='worldwide', bbox=(37.777, -122.352, 37.839, -122.086))
+defaults = dict(demdir='source', tiledir='out', tmpdir=None, source='worldwide', bbox=(37.777, -122.352, 37.839, -122.086), size=256)
 
 parser.set_defaults(**defaults)
 
@@ -42,6 +42,9 @@ parser.add_option('-s', '--source', dest='source',
 
 parser.add_option('--tmp-directory', dest='tmpdir',
                   help='Optional working directory for temporary files. Consider a ram disk for this.')
+
+parser.add_option('--tile-size', dest='size', type='int',
+                  help='Optional size for rendered tiles, default %(size)s.' % defaults)
 
 def generateCoordinates(ul, lr, zooms, padding):
     """ Generate a stream of (offset, count, coordinate) tuples for seeding.
@@ -108,7 +111,7 @@ if __name__ == '__main__':
         
         tiles = generateCoordinates(ul, lr, zooms, 0)
     
-    layer = SeedingLayer(options.demdir, options.tiledir, options.tmpdir, options.source)
+    layer = SeedingLayer(options.demdir, options.tiledir, options.tmpdir, options.source, options.size)
 
     for (offset, count, coord) in tiles:
         


### PR DESCRIPTION
add --tile-size argument to hillup-seed.py for making different size tiles, ex 512 for retina

```
python hillup-seed.py -b 41 -121 42 -120 --tile-size 512 4 5 6 7 8 9 10
```

defaults to 256, uses tilestache tile_height layer property under the hood
