### PR TITLE
resize final tile to match requested tile size in Hillup tilestache provider

### DIFF
--- a/Hillup/tiles.py
+++ b/Hillup/tiles.py
@@ -128,4 +128,9 @@ class Provider:
         if srs != SphericalMercator().srs:
             raise Exception('Tile projection must be spherical mercator, not "%(srs)s"' % locals())
         
-        return render_tile(self.source_dir, coord, 0)
+        rendered = render_tile(self.source_dir, coord, 0)
+
+        if rendered.size != (width, height):
+            rendered = rendered.resize((width, height), resample)
+
+        return rendered


### PR DESCRIPTION
Resize (if necessary) the tile returned from Hillup:Provider:renderTile to match the requested tile size.  As it was, Hillup:Provider was returning the native size of the elevation tile.  

This change, combined with https://github.com/migurski/DEM-Tools/pull/5 allows you to seed a set of 512px (retina) tiles and use them for both retina and non-retina (256px) implementations, where the 256px tiles are just downsampled from the 512px tiles.
